### PR TITLE
Porcentaje presupuestario contratos adjudicados

### DIFF
--- a/PorcentajePresupuestContAdjud
+++ b/PorcentajePresupuestContAdjud
@@ -1,0 +1,19 @@
+PREFIX pproc: <http://contsem.unizar.es/def/sector-publico/pproc#>
+PREFIX pc: <http://purl.org/procurement/public-contracts#>
+PREFIX gr: <http://purl.org/goodrelations/v1#>
+
+SELECT SUM(distinct ?impAdjudicacionConIVA) as ?total WHERE {
+
+?uriCont a pproc:Contract;
+pproc:contractProcedureSpecifications ?procedureType;
+pproc:contractObject/pproc:contractEconomicConditions/pproc:budgetPrice ?budgetPrice;
+pc:tender ?tender.
+?tender pproc:formalizedDate ?formalizedDate.
+?procedureType pproc:procedureType ?procedimiento.
+?tender pc:offeredPrice ?offeredPriceVAT.
+?offeredPriceVAT gr:hasCurrencyValue ?impAdjudicacionConIVA;
+gr:valueAddedTaxIncluded "true"^^xsd:boolean.
+FILTER (regex(?formalizedDate, "2014")
+AND (?procedimiento = pproc:RegularOpen OR ?procedimiento = pproc:Negotiated OR ?procedimiento = pproc:Minor ) )
+
+}


### PR DESCRIPTION
He añadido la consulta SPARQL sobre el:
Porcentaje en volumen presupuestario de los contratos adjudicados a través de cada uno de los procedimientos previstos en la legislación

En concreto esta consulta realiza:
Total anual (2014) de todos los tipos procedimientos (abierto, negociado y menor)